### PR TITLE
68 define ports separately

### DIFF
--- a/operators/FH_create_inp.py
+++ b/operators/FH_create_inp.py
@@ -163,79 +163,89 @@ def create_inp(self, context):
 
             first_node_index = node_index
             last_node_index = node_index + len(vertex_co_global)-1
-            ###NODES
-            textfile.write('* NODES \n')
-            for co in vertex_co_global:
-                textfile.write('N{} x={:.8f} y={:.8f} z={:.8f} \n' .format(node_index, co.x, co.y, co.z))
-                node_index +=1
-            
-            ###ELEMENTS
-            textfile.write('* SEGMENTS \n')
 
-            # this implements minimum twist method to capture the tangent, normal and binormal of the curve, the binormal is used to define segment orientation
-            # code from ChatGPT, not sure how the method works.
-            # I found if I use the global coordinates, the normal and binormal vectors give wrong orientation, so using local coordinates first and then applying object global tranform when writing to file
-            points = []
-            for vertex in object_vertices:
-                points.append((vertex.co) * scale )# + random_unit_vector(size=3)*1e-5)
+            # dont write nodes if curve type is port curve
+            if (obj.modifiers["BFH_curve"]["Socket_13"]) != 2:
+                
+                ###NODES
+                textfile.write('* NODES \n')
+                for co in vertex_co_global:
+                    textfile.write('N{} x={:.8f} y={:.8f} z={:.8f} \n' .format(node_index, co.x, co.y, co.z))
+                    node_index +=1
+                
+                ###ELEMENTS
+                textfile.write('* SEGMENTS \n')
 
-            frames = []
-            rotation_matrix = obj.rotation_euler.to_matrix().to_3x3()
+                # this implements minimum twist method to capture the tangent, normal and binormal of the curve, the binormal is used to define segment orientation
+                # code from ChatGPT, not sure how the method works.
+                # I found if I use the global coordinates, the normal and binormal vectors give wrong orientation, so using local coordinates first and then applying object global tranform when writing to file
+                points = []
+                for vertex in object_vertices:
+                    points.append((vertex.co) * scale )# + random_unit_vector(size=3)*1e-5)
 
-            for i in range(len(points) - 1):
-                p0 = points[i]
-                p1 = points[i + 1]
-                tangent = (p1 - p0).normalized()
+                frames = []
+                rotation_matrix = obj.rotation_euler.to_matrix().to_3x3()
 
-                if bpy.data.node_groups["BFH_curve"].nodes["Set Curve Normal"].mode == "Z_UP":
-                    # Always project global Z onto the plane perpendicular to tangent
-                    z_up = mathutils.Vector((0, 0, 1))
-                    if abs(tangent.dot(z_up)) > 0.99:
-                        z_up = mathutils.Vector((0, 1, 0))
-                    normal = (z_up - tangent * tangent.dot(z_up)).normalized()
-                else: #minimum twisr
-                    if i == 0:
-                        # Choose an up vector not parallel to the tangent
-                        up = mathutils.Vector((0, 0, 1))
-                        if abs(tangent.dot(up)) > 0.99:
-                            up = mathutils.Vector((0, 1, 0))
-                        # Project up onto plane ⟂ tangent
-                        projected = up - tangent * up.dot(tangent)
-                        normal = projected.normalized()
-                    else:
-                        prev_tangent, prev_normal, _ = frames[-1]
-                        axis = prev_tangent.cross(tangent)
-                        if axis.length < 1e-6:
-                            normal = prev_normal
+                for i in range(len(points) - 1):
+                    p0 = points[i]
+                    p1 = points[i + 1]
+                    tangent = (p1 - p0).normalized()
+
+                    if bpy.data.node_groups["BFH_curve"].nodes["Set Curve Normal"].mode == "Z_UP":
+                        # Always project global Z onto the plane perpendicular to tangent
+                        z_up = mathutils.Vector((0, 0, 1))
+                        if abs(tangent.dot(z_up)) > 0.99:
+                            z_up = mathutils.Vector((0, 1, 0))
+                        normal = (z_up - tangent * tangent.dot(z_up)).normalized()
+                    else: #minimum twisr
+                        if i == 0:
+                            # Choose an up vector not parallel to the tangent
+                            up = mathutils.Vector((0, 0, 1))
+                            if abs(tangent.dot(up)) > 0.99:
+                                up = mathutils.Vector((0, 1, 0))
+                            # Project up onto plane ⟂ tangent
+                            projected = up - tangent * up.dot(tangent)
+                            normal = projected.normalized()
                         else:
-                            angle = prev_tangent.angle(tangent)
-                            rot = mathutils.Matrix.Rotation(angle, 3, axis)
-                            normal = (rot @ prev_normal).normalized()
+                            prev_tangent, prev_normal, _ = frames[-1]
+                            axis = prev_tangent.cross(tangent)
+                            if axis.length < 1e-6:
+                                normal = prev_normal
+                            else:
+                                angle = prev_tangent.angle(tangent)
+                                rot = mathutils.Matrix.Rotation(angle, 3, axis)
+                                normal = (rot @ prev_normal).normalized()
 
-                binormal = tangent.cross(normal).normalized()
-                frames.append((tangent, normal, binormal))
+                    binormal = tangent.cross(normal).normalized()
+                    frames.append((tangent, normal, binormal))
 
-                rotated_binormal = rotation_matrix @ binormal
+                    rotated_binormal = rotation_matrix @ binormal
 
 
-                textfile.write('E{} N{} N{} w={:.8f} h={:.8f} wx={:.4F} wy={:.4F} wz={:.4F} \n' .format(element_index, first_node_index+i, first_node_index+i+1, w, h, rotated_binormal.x, rotated_binormal.y, rotated_binormal.z))
-                element_index +=1
-           
-            ## Check if connected to plane 
-            ###PORT
-            if (obj.modifiers["BFH_curve"]["Socket_7"]) and (obj.modifiers["BFH_curve"]["Socket_10"] is not None):
-                textfile.write(".equiv nin{} N{} \n" .format(obj_idx, first_node_index))
+                    textfile.write('E{} N{} N{} w={:.8f} h={:.8f} wx={:.4F} wy={:.4F} wz={:.4F} \n' .format(element_index, first_node_index+i, first_node_index+i+1, w, h, rotated_binormal.x, rotated_binormal.y, rotated_binormal.z))
+                    element_index +=1
+            
+                ## Check if connected to plane 
+                ###PORT
+                if (obj.modifiers["BFH_curve"]["Socket_13"]) != 2:
+                    if (obj.modifiers["BFH_curve"]["Socket_7"]) and (obj.modifiers["BFH_curve"]["Socket_10"] is not None):
+                        textfile.write(".equiv nin{} N{} \n" .format(obj_idx, first_node_index))
 
-                #check if plane interconect
-                if (obj.modifiers["BFH_curve"]["Socket_11"]):
-                    textfile.write(".equiv N{} nout{} \n" .format(last_node_index, obj_idx))
-                else:
-                    textfile.write('* PORTS \n')
-                    textfile.write('.external N{} nout{} \n' .format(last_node_index, obj_idx))
-            else:
-                # Get the evaluated object
+                        #check if plane interconect
+                        if (obj.modifiers["BFH_curve"]["Socket_11"]):
+                            textfile.write(".equiv N{} nout{} \n" .format(last_node_index, obj_idx))
+                        else:
+                            textfile.write('* PORTS \n')
+                            textfile.write('.external N{} nout{} \n' .format(last_node_index, obj_idx))
+                    else:
+                        # Get the evaluated object
+                        textfile.write('* PORTS \n')
+                        textfile.write('.external N{} N{} \n' .format(first_node_index, last_node_index) ) 
+
+            # if curve type is port curve
+            if (obj.modifiers["BFH_curve"]["Socket_13"]) == 2:
                 textfile.write('* PORTS \n')
-                textfile.write('.external N{} N{} \n' .format(first_node_index, last_node_index) ) 
+                textfile.write('.external nin{} nout{} \n' .format(obj_idx, obj_idx))
 
             obj.to_mesh_clear()
 


### PR DESCRIPTION
This PR now allows curves to be used to define ports, 
For now this is limited to defining ports between two planes
To distinguish between the three possible curves, which are the original BFH_curve with its own port definition, and the plane_interconnect curve, and now the port curve, the BFH_modifier now has a drop down menu that can select between the three curves, for each curve the modifier panel will change to hide and show the properties that are only relevant to the curve

BFH_curve 
<img width="598" height="634" alt="image" src="https://github.com/user-attachments/assets/d2cf5384-f184-4297-90ac-c3c64f98c3f7" />

Plane interconnect curve 
<img width="592" height="488" alt="image" src="https://github.com/user-attachments/assets/207670ba-7a9e-40c0-8fd4-4f346f57888d" />

Port curve
<img width="586" height="284" alt="image" src="https://github.com/user-attachments/assets/93b58dc9-fa66-429a-b22a-636e390be741" />

Closes 68